### PR TITLE
google maps redirect

### DIFF
--- a/app/controllers/bars_controller.rb
+++ b/app/controllers/bars_controller.rb
@@ -26,7 +26,7 @@ class BarsController < ApplicationController
 
   def show
     @bar = Bar.find(params[:id])
-    query = "https://www.google.com/maps/search/?api=1&query=#{@bar.name} #{@bar.address}"
+    query = "https://www.google.com/maps?saddr=My+Location&daddr=#{@bar.name}+#{@bar.address}"
     @query_encode = URI::Parser.new.escape(query)
   end
 

--- a/app/views/bars/show.html.erb
+++ b/app/views/bars/show.html.erb
@@ -85,5 +85,5 @@
         </div>
     </div>
   </div>
-    <%= link_to "Take me there!", @query_encode, class: "main-btn redirect-button-margin" %>
+    <%= link_to "Take me there!", @query_encode, class: "main-btn redirect-button-margin", target: "_blank" %>
 </div>


### PR DESCRIPTION
-gmaps link opens in new tab
-query changed so that it opens the map already with the directions (starting point current location, destination being the bar)