### PR TITLE
Reset Mapbox API Initial View

### DIFF
--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -10,8 +10,9 @@ export default class extends Controller {
   connect() {
     mapboxgl.accessToken = this.apiKeyValue;
 
-    const successLocation = (position) => {
-      this.setupMap([position.coords.longitude, position.coords.latitude]);
+    const successLocation = () => {
+      // this is to dictate where the map initially loads
+      this.setupMap([-0.047793,51.539311]);
     };
 
     const errorLocation = () => {
@@ -22,48 +23,55 @@ export default class extends Controller {
       enableHighAccuracy: true
     });
 
-    this.setupMap = (center) => {
-      this.map = new mapboxgl.Map({
-        container: this.element,
-        style: "mapbox://styles/luc-kelly/clxa5si9h024001qx2v483cr5",
-        center: center,
-        zoom: 15
-      });
-
-      this.map.on('load', () => {
-        this.map.addSource('point', {
-          'type': 'geojson',
-          'data': {
-            'type': 'Feature',
-            'geometry': {
-              'type': 'Point',
-              'coordinates': center
-            }
-          }
+      this.setupMap = (center) => {
+        this.map = new mapboxgl.Map({
+          container: this.element,
+          style: "mapbox://styles/luc-kelly/clxa5si9h024001qx2v483cr5",
+          center: center,
+          zoom: 10
         });
 
-        this.map.addLayer({
-          'id': 'point',
-          'type': 'circle',
-          'source': 'point',
-          'paint': {
-            'circle-radius': 10,
-            'circle-color': '#007cbf'
-          }
-        });
-      });
 
-      document.getElementById('btn-center').addEventListener('click', () => {
-        navigator.geolocation.getCurrentPosition((position) => {
-          this.map.flyTo({
-            center: [position.coords.longitude, position.coords.latitude],
-            essential: true
+          this.map.on('load', () => {
+            navigator.geolocation.getCurrentPosition((position) => {
+
+              this.map.addSource('point', {
+                'type': 'geojson',
+                'data': {
+                  'type': 'Feature',
+                  'geometry': {
+                    'type': 'Point',
+                    'coordinates': [position.coords.longitude, position.coords.latitude]
+                  }
+                }
+              });
+              this.map.addLayer({
+                'id': 'point',
+                'type': 'circle',
+                'source': 'point',
+                'paint': {
+                  'circle-radius': 10,
+                  // change to vibez colours
+                  'circle-color': '#007cbf'
+                }
+              });
+          });
+
+
+          });
+
+
+          document.getElementById('btn-center').addEventListener('click', () => {
+            navigator.geolocation.getCurrentPosition((position) => {
+              this.map.flyTo({
+                center: [position.coords.longitude, position.coords.latitude],
+                essential: true
+              });
           });
         });
-      });
 
-      this.#addMarkersToMap();
-    };
+        this.#addMarkersToMap();
+      };
   }
     #addMarkersToMap() {
       this.markersValue.forEach((marker) => {


### PR DESCRIPTION
All changes made to mapbox stimulus controller file 

Changed the initial view to central london from user's current location. 

This is to reflect the locations of the bars that are seeded in the app which predominantly spaced around central/east london. 

And so preventing the scenario where a user logs in from outside central london and does not see any bars on their map.

Finally, I also ensured that current location feature still works as intended. 
